### PR TITLE
Implement Phase 1 backend skeleton

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-name: install
+name: tests
 on: [push, pull_request]
 jobs:
-  install:
+  tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,3 +21,5 @@ jobs:
       - name: Install frontend deps
         working-directory: frontend
         run: pnpm install
+      - name: Run tests
+        run: pixi run pytest -q

--- a/backend/src/cadabra/__init__.py
+++ b/backend/src/cadabra/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/backend/src/cadabra/__main__.py
+++ b/backend/src/cadabra/__main__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import uvicorn
+
+if __name__ == "__main__":
+    uvicorn.run("cadabra.main:create_app", factory=True, host="0.0.0.0", port=8000)

--- a/backend/src/cadabra/api/__init__.py
+++ b/backend/src/cadabra/api/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/backend/src/cadabra/api/trays.py
+++ b/backend/src/cadabra/api/trays.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+from fastapi import APIRouter, BackgroundTasks
+
+from ..models.trays import TrayDownload, TrayRequest, TrayStatus
+from ..services.trays import build_tray
+
+router = APIRouter(prefix="/trays", tags=["trays"])
+
+
+@router.post("/", response_model=TrayStatus)
+def start_tray(request: TrayRequest, background_tasks: BackgroundTasks) -> TrayStatus:
+    job_id = str(uuid4())
+    background_tasks.add_task(build_tray, job_id)
+    return TrayStatus(job_id=job_id, status="queued")
+
+
+@router.get("/{job_id}", response_model=TrayStatus)
+def check_tray(job_id: str) -> TrayStatus:
+    path = Path("/tmp/trays") / job_id / "tray.stl"
+    if path.exists():
+        status = "complete"
+    else:
+        status = "queued"
+    return TrayStatus(job_id=job_id, status=status)
+
+
+@router.get("/{job_id}/download", response_model=TrayDownload)
+def download_tray(job_id: str) -> TrayDownload:
+    return TrayDownload(job_id=job_id, download_url=f"/tmp/trays/{job_id}/tray.stl")

--- a/backend/src/cadabra/main.py
+++ b/backend/src/cadabra/main.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+
+from .api import trays
+
+
+def load_description() -> str:
+    root = Path(__file__).resolve().parents[3]
+    path = root / "memory-bank" / "projectbrief.md"
+    return path.read_text()
+
+
+def create_app() -> FastAPI:
+    description = load_description()
+    tags_metadata = [
+        {"name": "health", "description": "Service status check"},
+        {
+            "name": "trays",
+            "description": "Generate custom trays from object silhouettes",
+        },
+    ]
+    app = FastAPI(
+        title="cadabra API",
+        description=description,
+        openapi_tags=tags_metadata,
+    )
+
+    @app.get("/health", tags=["health"])
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    app.include_router(trays.router)
+    return app

--- a/backend/src/cadabra/models/__init__.py
+++ b/backend/src/cadabra/models/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/backend/src/cadabra/models/trays.py
+++ b/backend/src/cadabra/models/trays.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class TrayRequest(BaseModel):
+    depth: float = 0.0
+    offset: float = 0.0
+
+
+class TrayStatus(BaseModel):
+    job_id: str
+    status: str
+
+
+class TrayDownload(BaseModel):
+    job_id: str
+    download_url: str

--- a/backend/src/cadabra/services/__init__.py
+++ b/backend/src/cadabra/services/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/backend/src/cadabra/services/trays.py
+++ b/backend/src/cadabra/services/trays.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from pathlib import Path
+
+placeholder_stl = "solid placeholder\nendsolid placeholder\n"
+
+
+def build_tray(job_id: str) -> None:
+    out_dir = Path("/tmp/trays") / job_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "tray.stl").write_text(placeholder_stl)

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,13 +1,12 @@
-# Active Context (01 Jul 2025)
+# Active Context (06 Jul 2025)
 
-* **Focus** – Kick-off: initialise Memory Bank; agree on slug; scaffold repo.
+* **Focus** – Backend skeleton complete; start Docker and frontend scaffolding.
 * **Immediate next steps** (see [`techContext.md`](./techContext.md) for stack details)
 
-  1. Pick and register project slug (`cadabra`).
-  2. `pixi init --format pyproject` → add FastAPI, CadQuery, pytest.
-  3. `pnpm init` → add React, Vite, TypeScript, ESLint, Prettier.
-  4. Create multi-stage Dockerfile using `mambaorg/pixi` base.
-  5. Set up GitHub Actions (lint, test, docker-build, licence check).
+  1. Create multi-stage Dockerfile using `mambaorg/pixi` base.
+  2. Add docker-compose for local dev.
+  3. Scaffold React frontend with Vite + TypeScript.
+  4. Extend GitHub Actions to build and push Docker images.
 
 * **Decisions** (see [`systemPatterns.md`](./systemPatterns.md) for full rationale)
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -7,6 +7,7 @@
 | 2025-07-01   | Repository scaffolding                                | ✅ |
 | –            | Frontend skeleton (React)                             | ⏳             |
 | 2025-07-05   | FastAPI skeleton + health check                       | ✅        |
+| 2025-07-06   | Backend skeleton with trays API and CI workflow       | ✅   |
 | –            | Docker & CI pipeline                                  | ⏳             |
 | –            | Silhouette tracing MVP                                | ⏳             |
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -6,7 +6,7 @@
 | 2025-07-01   | Memory Bank initialised with core files & [C4 diagrams](./systemPatterns.md) | ✅             |
 | 2025-07-01   | Repository scaffolding                                | ✅ |
 | –            | Frontend skeleton (React)                             | ⏳             |
-| –            | FastAPI skeleton + health check                       | ⏳             |
+| 2025-07-05   | FastAPI skeleton + health check                       | ✅        |
 | –            | Docker & CI pipeline                                  | ⏳             |
 | –            | Silhouette tracing MVP                                | ⏳             |
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 version: 6
 environments:
   default:
@@ -9,10 +10,12 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.9.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/black-25.1.0-pyh866005b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.6.15-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.6.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py313hfab6e84_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.2.1-pyh707e725_0.conda
@@ -24,8 +27,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.12-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
@@ -84,6 +94,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
@@ -99,13 +110,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/bd/0b9914104b9a6e9fd75566c993ed6e97767735acffbab6997a29c3fd94c3/cadquery-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/50/b1222562c6d270fea83e9c9075b8e8600b8479150a18e4516a6138b980d1/fastapi-0.115.14-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/eb/3c/f4abd740877a35abade05e437245b192f9d0ffb48bbbbd708df33d3cda37/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl
       - pypi: ./
@@ -138,31 +146,25 @@ packages:
   requires_dist:
   - typing-extensions>=4.0.0 ; python_full_version < '3.9'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl
-  name: anyio
-  version: 4.9.0
-  sha256: 9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c
-  requires_dist:
-  - exceptiongroup>=1.0.2 ; python_full_version < '3.11'
-  - idna>=2.8
-  - sniffio>=1.1
-  - typing-extensions>=4.5 ; python_full_version < '3.13'
-  - trio>=0.26.1 ; extra == 'trio'
-  - anyio[trio] ; extra == 'test'
-  - blockbuster>=1.5.23 ; extra == 'test'
-  - coverage[toml]>=7 ; extra == 'test'
-  - exceptiongroup>=1.2.0 ; extra == 'test'
-  - hypothesis>=4.0 ; extra == 'test'
-  - psutil>=5.9 ; extra == 'test'
-  - pytest>=7.0 ; extra == 'test'
-  - trustme ; extra == 'test'
-  - truststore>=0.9.1 ; python_full_version >= '3.10' and extra == 'test'
-  - uvloop>=0.21 ; python_full_version < '3.14' and platform_python_implementation == 'CPython' and sys_platform != 'win32' and extra == 'test'
-  - packaging ; extra == 'doc'
-  - sphinx~=8.2 ; extra == 'doc'
-  - sphinx-rtd-theme ; extra == 'doc'
-  - sphinx-autodoc-typehints>=1.2.0 ; extra == 'doc'
-  requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.9.0-pyh29332c3_0.conda
+  sha256: b28e0f78bb0c7962630001e63af25a89224ff504e135a02e50d4d80b6155d386
+  md5: 9749a2c77a7c40d432ea0927662d7e52
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.9
+  - sniffio >=1.1
+  - typing_extensions >=4.5
+  - python
+  constrains:
+  - trio >=0.26.1
+  - uvloop >=0.21
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/anyio?source=hash-mapping
+  size: 126346
+  timestamp: 1742243108743
 - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
   sha256: 93b14414b3b3ed91e286e1cbe4e7a60c4e1b1c730b0814d1e452a8ac4b9af593
   md5: 8f587de4bcf981e26228f268df374a9b
@@ -215,7 +217,7 @@ packages:
 - pypi: ./
   name: cadabra
   version: 0.1.0
-  sha256: 05fef1a38b6ef25addabd78d9b17ce90161077f68c9995cb618ba3fa3791f19f
+  sha256: 0535733848ac24019118aa584f7a566be614b8a31bc564127f0385ba124d22e8
   requires_dist:
   - fastapi
   - cadquery
@@ -233,6 +235,16 @@ packages:
   - click==8.0.4 ; extra == 'dev'
   - ipython ; extra == 'ipython'
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.6.15-pyhd8ed1ab_0.conda
+  sha256: d71c85835813072cd6d7ce4b24be34215cd90c104785b15a5d58f4cd0cb50778
+  md5: 781d068df0cc2407d4db0ecfbb29225b
+  depends:
+  - python >=3.9
+  license: ISC
+  purls:
+  - pkg:pypi/certifi?source=hash-mapping
+  size: 155377
+  timestamp: 1749972291158
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py313hfab6e84_0.conda
   sha256: 73cd6199b143a8a6cbf733ce124ed57defc1b9a7eab9b10fd437448caf8eaa45
   md5: ce6386a5892ef686d6d680c345c40ad1
@@ -391,6 +403,85 @@ packages:
   - pkg:pypi/filelock?source=hash-mapping
   size: 17887
   timestamp: 1741969612334
+- conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhd8ed1ab_0.conda
+  sha256: f64b68148c478c3bfc8f8d519541de7d2616bf59d44485a5271041d40c061887
+  md5: 4b69232755285701bc86a5afe4d9933a
+  depends:
+  - python >=3.9
+  - typing_extensions
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/h11?source=hash-mapping
+  size: 37697
+  timestamp: 1745526482242
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
+  sha256: 0aa1cdc67a9fe75ea95b5644b734a756200d6ec9d0dff66530aec3d1c1e9df75
+  md5: b4754fb1bdcb70c8fd54f918301582c6
+  depends:
+  - hpack >=4.1,<5
+  - hyperframe >=6.1,<7
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/h2?source=hash-mapping
+  size: 53888
+  timestamp: 1738578623567
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+  sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+  md5: 0a802cb9888dd14eeefc611f05c40b6e
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/hpack?source=hash-mapping
+  size: 30731
+  timestamp: 1737618390337
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+  sha256: 04d49cb3c42714ce533a8553986e1642d0549a05dc5cc48e0d43ff5be6679a5b
+  md5: 4f14640d58e2cc0aa0819d9d8ba125bb
+  depends:
+  - python >=3.9
+  - h11 >=0.16
+  - h2 >=3,<5
+  - sniffio 1.*
+  - anyio >=4.0,<5.0
+  - certifi
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/httpcore?source=hash-mapping
+  size: 49483
+  timestamp: 1745602916758
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+  sha256: cd0f1de3697b252df95f98383e9edb1d00386bfdd03fdf607fa42fe5fcb09950
+  md5: d6989ead454181f4f9bc987d3dc4e285
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/httpx?source=hash-mapping
+  size: 63082
+  timestamp: 1733663449209
+- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+  sha256: 77af6f5fe8b62ca07d09ac60127a30d9069fdc3c68d6b256754d0ffb1f7779f8
+  md5: 8e6923fc12f1fe8f8c4e5c9f343256ac
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/hyperframe?source=hash-mapping
+  size: 17397
+  timestamp: 1737618427549
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
   sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
   md5: 8b189310083baabfb622af68fd9d3ae3
@@ -415,16 +506,17 @@ packages:
   - pkg:pypi/identify?source=compressed-mapping
   size: 78926
   timestamp: 1748049754416
-- pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
-  name: idna
-  version: '3.10'
-  sha256: 946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-  requires_dist:
-  - ruff>=0.6.2 ; extra == 'all'
-  - mypy>=1.11.2 ; extra == 'all'
-  - pytest>=8.3.2 ; extra == 'all'
-  - flake8>=7.1.1 ; extra == 'all'
-  requires_python: '>=3.6'
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+  sha256: d7a472c9fd479e2e8dcb83fb8d433fce971ea369d704ece380e876f9c3494e87
+  md5: 39a4f67be3286c86d696df570b1201b7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/idna?source=hash-mapping
+  size: 49765
+  timestamp: 1733211921194
 - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
   sha256: c18ab120a0613ada4391b15981d86ff777b5690ca461ea7e9e49531e8f374745
   md5: 63ccfdc3a3ce25b027b8767eb722fca8
@@ -1184,11 +1276,17 @@ packages:
   - pkg:pypi/six?source=hash-mapping
   size: 16385
   timestamp: 1733381032766
-- pypi: https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl
-  name: sniffio
-  version: 1.3.1
-  sha256: 2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2
-  requires_python: '>=3.7'
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+  sha256: c2248418c310bdd1719b186796ae50a8a77ce555228b6acd32768e2543a15012
+  md5: bf7a226e58dfb8346c70df36065d86c9
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/sniffio?source=hash-mapping
+  size: 15019
+  timestamp: 1733244175724
 - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
   sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
   md5: b1b505328da7a6b246787df4b5a49fbc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 [project]
 authors = [{ name = "Christian Fobel", email = "christian@fobel.net" }]
 name = "cadabra"
@@ -8,6 +9,9 @@ dependencies = ["fastapi", "cadquery"]
 [build-system]
 build-backend = "hatchling.build"
 requires = ["hatchling"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["backend/src/cadabra"]
 
 [tool.pixi.project]
 channels = ["conda-forge"]
@@ -26,6 +30,7 @@ pytest = ">=8.4.1,<9"
 nodejs = ">=22.13.0,<22.14"
 pre-commit = ">=4.2.0,<5"
 markdownlint-cli2 = ">=0.18.1,<0.19"
+httpx = ">=0.27.0,<0.29"
 
 [tool.black]
 line-length = 88

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+from fastapi.testclient import TestClient
+
+from cadabra.main import create_app
+
+
+def test_health() -> None:
+    client = TestClient(create_app())
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add FastAPI backend skeleton with `/health` endpoint
- define Pydantic models, tray router and background task
- load API description from projectbrief and register OpenAPI tags
- run tests in CI using Pixi environment
- restructure backend to use src layout
- add SPDX headers and update `pixi.lock`

## Testing
- `./pixi run pre-commit run --files pyproject.toml pixi.lock`
- `./pixi run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68674778a910832ca646ff2902f6ee21